### PR TITLE
fixed firefox getting stuck switching songs

### DIFF
--- a/components/Widget/MusicPlayer.vue
+++ b/components/Widget/MusicPlayer.vue
@@ -121,8 +121,7 @@ export default defineComponent({
             await this.fadeOut(3000);
             for (const callback of this.switchSongsCallbacks) callback();
             this.switchSongsCallbacks = [];
-            if (this.audio.readyState >= 3) this.playMusic();
-            else this.waitingToPlay = true;
+            this.waitingToPlay = true;
         },
         fadeOut(time: number) {
             return new Promise<void>((resolve) => {


### PR DESCRIPTION
it appears to be a firefox bug where the audio readystate doesn't properly update when you change the audio src, getting stuck at 4 even though the song has not been loaded